### PR TITLE
fix(payment): round payment amount before generating payment intent

### DIFF
--- a/src/controllers/payment.controller.ts
+++ b/src/controllers/payment.controller.ts
@@ -57,7 +57,7 @@ export const handleCreateAppointmentPaymentIntent = handleAsyncHttp(
 			appointment.paymentId = payment._id;
 			await appointment.save();
 		}
-		const intent = await generatePaymentIntent(payAmount * 100, currency, {
+		const intent = await generatePaymentIntent(Math.round(payAmount * 100), currency, {
 			// transfer_data: {
 			//     destination: provider.providerSettings?.stripeAccountId,
 			// },


### PR DESCRIPTION
Ensured the payment amount is rounded to the nearest whole number before creating the payment intent. This change prevents potential issues with fractional amounts being processed.

- Updated payAmount calculation to use Math.round
- Improved accuracy of payment processing